### PR TITLE
Changes to electromagnetism.py regarding mini arrows and z_index

### DIFF
--- a/src/manim_physics/electromagnetism.py
+++ b/src/manim_physics/electromagnetism.py
@@ -32,7 +32,7 @@ class Charge(VGroup):
             layer_colors = ["#3399FF", "#66B2FF"]
             layer_radius = 2
 
-        if add_glow: # use many arcs to simulate glowing
+        if add_glow:  # use many arcs to simulate glowing
             layer_num = 80
             color_list = color_gradient(layer_colors, layer_num)
             opacity_func = lambda t: 1500 * (1 - abs(t - 0.009) ** 0.0001)
@@ -73,8 +73,6 @@ class ElectricField(ArrowVectorField):
             p0, mag = charge.get_center(), charge.magnitude
             pos.append(p0)
             x, y, z = p - p0
-            if x == 0 and y == 0:
-                return np.zeros(3)
             dist = (x ** 2 + y ** 2) ** 1.5
             if all((p - p0) ** 2 > 0.01):
                 direction += mag * np.array([x / dist, y / dist, 0])

--- a/src/manim_physics/electromagnetism.py
+++ b/src/manim_physics/electromagnetism.py
@@ -73,12 +73,12 @@ class ElectricField(ArrowVectorField):
             pos.append(p0)
             x, y, z = p - p0
             dist = (x ** 2 + y ** 2) ** 1.5
-            if all((p - p0) ** 2 > 0.01):
+            if any((p - p0) ** 2 > 0.05):
                 direction += mag * np.array([x / dist, y / dist, 0])
             else:
                 direction += np.zeros(3)
         for p0 in pos:
-            if all((p - p0) **2 <= 0.01):
+            if all((p - p0) ** 2 <= 0.05):
                 direction = np.zeros(3)
         return direction
 

--- a/src/manim_physics/electromagnetism.py
+++ b/src/manim_physics/electromagnetism.py
@@ -62,7 +62,6 @@ class ElectricField(ArrowVectorField):
         self.charges = charges
         super().__init__(
             lambda p: self.field_func(p),
-            length_func=lambda norm: 0.4 * sigmoid(norm),
             **kwargs
         )
 

--- a/src/manim_physics/electromagnetism.py
+++ b/src/manim_physics/electromagnetism.py
@@ -20,8 +20,8 @@ class Charge(VGroup):
 
         if magnitude > 0:
             label = VGroup(
-                Rectangle(width=0.32 * 1.1, height=0.006 * 1.1),
-                Rectangle(width=0.006 * 1.1, height=0.32 * 1.1),
+                Rectangle(width=0.32 * 1.1, height=0.006 * 1.1).set_z_index(1),
+                Rectangle(width=0.006 * 1.1, height=0.32 * 1.1).set_z_index(1),
             )
             color = RED
             layer_colors = [RED_D, RED_A]
@@ -53,6 +53,8 @@ class Charge(VGroup):
 
         self.add(Dot(point=self.point, radius=self.radius, color=color))
         self.add(label.scale(self.radius / 0.3).shift(point))
+        for mob in self:
+            mob.set_z_index(1)
 
 
 class ElectricField(ArrowVectorField):

--- a/tests/test_pendulum.py
+++ b/tests/test_pendulum.py
@@ -4,12 +4,13 @@ from manim_physics import *
 
 class PendulumExample(SpaceScene):
     def construct(self):
-        pends = VGroup(*[Pendulum(i) for i in np.linspace(1,5,7)])
+        pends = VGroup(*[Pendulum(i) for i in np.linspace(1, 5, 7)])
         self.add(pends)
         for p in pends:
             self.make_rigid_body(p.bobs)
             p.start_swinging()
         self.wait(10)
+
 
 class MultiPendulumExample(SpaceScene):
     def construct(self):


### PR DESCRIPTION
Changes include:
- typo; from `all` to `any`
- charge has a default z_index 1 which brings them above all else in an electric field
- lint

Tests were made locally, feel free to test them too for problems i may overlooked.