### PR TITLE
Added `GRAVITY` attribute to `SpaceScene`

### DIFF
--- a/src/manim_physics/rigid_mechanics.py
+++ b/src/manim_physics/rigid_mechanics.py
@@ -6,16 +6,18 @@ from manim import *
 
 
 class Space(Mobject, metaclass=ConvertToOpenGL):
-    def __init__(self, **kwargs):
+    def __init__(self, gravity: tuple[float, float] = (0, -9.81), **kwargs):
         super().__init__(**kwargs)
         self.space = pymunk.Space()
-        self.space.gravity = 0, -9.8
+        self.space.gravity = gravity
         self.space.sleep_time_threshold = 5
 
 
 class SpaceScene(Scene):
+    GRAVITY: tuple[float, float] = 0, -9.81
+
     def __init__(self, renderer=None, **kwargs):
-        self.space = Space()
+        self.space = Space(gravity=self.GRAVITY)
         super().__init__(renderer=renderer, **kwargs)
 
     def setup(self):


### PR DESCRIPTION
Added `GRAVITY` class method to `SpaceScene`.

**IMPORTANT** When changing `GRAVITY`, you need to rerender all partial videos. Simply disable the caching by providing the `disable_caching` flag.

Example
```bash
manim --disable_caching -pqh physics.py FallingEquation
```