### PR TITLE
Update ```rigid_mechanics.py``` to support Ellipse

### DIFF
--- a/manim_physics/rigid_mechanics/rigid_mechanics.py
+++ b/manim_physics/rigid_mechanics/rigid_mechanics.py
@@ -209,7 +209,10 @@ def _simulate(b):
 
 def get_shape(mob: VMobject) -> None:
     """Obtains the shape of the body from the mobject"""
-    if isinstance(mob, Circle):
+    if isinstance(mob, Ellipse):
+        vertices = [(a, b) for a, b, _ in mob.get_start_anchors() - mob.get_center()]
+        mob.shape = pymunk.Poly(mob.body, vertices)
+    elif isinstance(mob, Circle):
         mob.shape = pymunk.Circle(body=mob.body, radius=mob.radius)
     elif isinstance(mob, Line):
         mob.shape = pymunk.Segment(


### PR DESCRIPTION
When I tried to apply ```make_rigid_body()``` on an ```Ellipse```, it acted weirdly and soon I found its collision box was a circle. When ```get_shape()``` was checking its shape, it fell into the category of ```Circle``` due to the following code:
```Python
if isinstance(mob, Circle):
        mob.shape = pymunk.Circle(body=mob.body, radius=mob.radius)
```
Adding an if statement solved this bug:
```Python
if isinstance(mob, Ellipse):
        vertices = [(a, b) for a, b, c in mob.get_start_anchors() - mob.get_center()]
        mob.shape = pymunk.Poly(mob.body, vertices)
elif isinstance(mob, Circle):
        mob.shape = pymunk.Circle(body=mob.body, radius=mob.radius)
```